### PR TITLE
chore(pubspec): Widen the analyzer constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.13.0+1
+  * Widen the constraint on analyzer.
+
 #### 0.13.0
   * Don't output log files by default in release mode, and provide option to
     turn them off entirely.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observe
-version: 0.13.0
+version: 0.13.0+1
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: >
   Observable properties and objects for use in template_binding.
@@ -9,7 +9,7 @@ description: >
   user input into the DOM is immediately assigned to the model.
 homepage: https://www.dartlang.org/polymer-dart/
 dependencies:
-  analyzer: '>=0.15.6 <0.23.0'
+  analyzer: '>=0.15.6 <0.25.0'
   barback: '>=0.14.2 <0.16.0'
   logging: '>=0.9.0 <0.10.0'
   path: '>=0.9.0 <2.0.0'


### PR DESCRIPTION
Allow use of package:analyzer <0.25.0. Analyzer earlier than 0.24.0 has
issues with parsing `async` and `await`, this allows the use of
Observable with code that needs process such code with analyzer.
