### PR TITLE
Fix infinite loop when sorting from reaction function

### DIFF
--- a/lib/src/observable_list.dart
+++ b/lib/src/observable_list.dart
@@ -91,7 +91,7 @@ class ObservableList<E> extends ListBase<E> with ChangeNotifier {
 
   @reflectable void operator []=(int index, E value) {
     var oldValue = _list[index];
-    if (hasListObservers) {
+    if (hasListObservers && oldValue != value) {
       _recordChange(new ListChangeRecord(this, index, addedCount: 1,
           removed: [oldValue]));
     }

--- a/test/observable_list_test.dart
+++ b/test/observable_list_test.dart
@@ -299,7 +299,6 @@ _runTests() {
 }
 
 ObservableList list;
-int _loopCounter = 0;
 
 _lengthChange(int oldValue, int newValue) =>
     new PropertyChangeRecord(list, #length, oldValue, newValue);
@@ -307,9 +306,3 @@ _lengthChange(int oldValue, int newValue) =>
 _change(index, {removed: const [], addedCount: 0}) => new ListChangeRecord(
     list, index, removed: removed, addedCount: addedCount);
 
-Function _reSort(list) => (changes) {
-  if (_loopCounter++ > 50) {
-    throw 'INFINITE LOOP';
-  }
-  list.sort();
-};

--- a/test/observable_list_test.dart
+++ b/test/observable_list_test.dart
@@ -269,6 +269,16 @@ _runTests() {
       });
     });
 
+    test('sort or 2 elements from reaction fn', () {
+      ObservableList list = toObservable([3, 1]);
+      var futureSub = list.listChanges.listen(_reSort(list));
+      list.sort();
+      expect(list, [1, 3]);
+      // Delay clean up, because terminating listeners immediately hides bug.
+      new Future.delayed(
+          new Duration(milliseconds: 1), () => futureSub.cancel());
+    });
+    
     test('clear', () {
       list.clear();
       expect(list, []);
@@ -286,9 +296,17 @@ _runTests() {
 }
 
 ObservableList list;
+int _loopCounter = 0;
 
 _lengthChange(int oldValue, int newValue) =>
     new PropertyChangeRecord(list, #length, oldValue, newValue);
 
 _change(index, {removed: const [], addedCount: 0}) => new ListChangeRecord(
     list, index, removed: removed, addedCount: addedCount);
+
+Function _reSort(list) => (changes) {
+  if (_loopCounter++ > 50) {
+    throw 'INFINITE LOOP';
+  }
+  list.sort();
+};

--- a/test/observable_list_test.dart
+++ b/test/observable_list_test.dart
@@ -269,14 +269,17 @@ _runTests() {
       });
     });
 
-    test('sort or 2 elements from reaction fn', () {
-      ObservableList list = toObservable([3, 1]);
-      var futureSub = list.listChanges.listen(_reSort(list));
+    test('sort of 2 elements', () {
+      var list = toObservable([3, 1]);
+      // Dummy listener to record changes.
+      // TODO(jmesserly): should we just record changes always, to support the sync api?
+      sub = list.listChanges.listen((records) => null);
       list.sort();
-      expect(list, [1, 3]);
-      // Delay clean up, because terminating listeners immediately hides bug.
-      new Future.delayed(
-          new Duration(milliseconds: 1), () => futureSub.cancel());
+      expect(list.deliverListChanges(), true);
+      list.sort();
+      expect(list.deliverListChanges(), false);
+      list.sort();
+      expect(list.deliverListChanges(), false);
     });
     
     test('clear', () {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/observe/issues/79
