### PR TITLE
Delete "barback" from test config

### DIFF
--- a/.test_config
+++ b/.test_config
@@ -1,5 +1,0 @@
-{
-  "test_package": {
-    "barback": true
-  }
-}


### PR DESCRIPTION
This option seems to be wrong, and is breaking the testing on the package bots.

Currently, they are running "pub build test" and "pub run test build/test", and reporting all sorts of errors on all platforms.

If we do a clean checkout of observe, and run "pub get" "pub build test" then:
pub run test build/test
reports "ran 0 tests" on all platforms (vm, chrome, firefox, dartium)
and
pub run test
or 
pub run test test
run all the tests, and they all pass, on all platforms.
On platforms like chrome and firefox, the command compiles the tests to a temporary directory and runs them from there.

Therefore, I think that omitting the "barback" setting, and therefore running "pub run test" instead of "pub run test build/test" is the right way to test these.