### PR TITLE
update to use new analyzer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.15.1
+
+* Update to use new analyzer API
+
 #### 0.14.0
 
 * Update to be built on top of `package:observable`. Contains the following

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -259,7 +259,7 @@ SimpleIdentifier _getSimpleIdentifier(Identifier id) =>
     id is PrefixedIdentifier ? id.identifier : id;
 
 bool _hasKeyword(Token token, Keyword keyword) =>
-    token?.type == TokenType.KEYWORD && token.lexeme == keyword.syntax;
+    token?.type.isKeyword && token.lexeme == keyword.syntax;
 
 String _getOriginalCode(TextEditTransaction code, AstNode node) =>
     code.original.substring(node.offset, node.end);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observe
-version: 0.15.0
+version: 0.15.1
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: >
   Observable properties and objects for use in template_binding.
@@ -9,7 +9,7 @@ description: >
   user input into the DOM is immediately assigned to the model.
 homepage: https://www.dartlang.org/polymer-dart/
 dependencies:
-  analyzer: ^0.27.0
+  analyzer: '>=0.29.11 <0.30.0'
   barback: '>=0.14.2 <0.16.0'
   func: ^0.1.0
   logging: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
Update internals to use the new analyzer API.
See dart-lang/sdk#29519

Blocked on https://github.com/dart-lang/smoke/pull/33