### PR TITLE
Zone.strong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.15.2
+
+* Update to use strong-mode clean Zone API.
+
 #### 0.15.1
 
 * Update to use new analyzer API

--- a/lib/src/dirty_check.dart
+++ b/lib/src/dirty_check.dart
@@ -107,7 +107,8 @@ ZoneSpecification dirtyCheckZoneSpec() {
     });
   }
 
-  Func0 wrapCallback(Zone self, ZoneDelegate parent, Zone zone, f()) {
+  ZoneCallback<R> wrapCallback<R>(
+      Zone self, ZoneDelegate parent, Zone zone, R f()) {
     // TODO(jmesserly): why does this happen?
     if (f == null) return f;
     return () {
@@ -116,7 +117,8 @@ ZoneSpecification dirtyCheckZoneSpec() {
     };
   }
 
-  Func1 wrapUnaryCallback(Zone self, ZoneDelegate parent, Zone zone, f(x)) {
+  ZoneCallback<R, T> wrapUnaryCallback<R, T>(
+      Zone self, ZoneDelegate parent, Zone zone, R f(T x)) {
     // TODO(jmesserly): why does this happen?
     if (f == null) return f;
     return (x) {

--- a/lib/src/dirty_check.dart
+++ b/lib/src/dirty_check.dart
@@ -117,7 +117,7 @@ ZoneSpecification dirtyCheckZoneSpec() {
     };
   }
 
-  ZoneCallback<R, T> wrapUnaryCallback<R, T>(
+  ZoneUnaryCallback<R, T> wrapUnaryCallback<R, T>(
       Zone self, ZoneDelegate parent, Zone zone, R f(T x)) {
     // TODO(jmesserly): why does this happen?
     if (f == null) return f;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   test: '^0.12.18+1'
   stack_trace: '>=0.9.1 <2.0.0'
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: ">=1.25.0 <2.0.0"
 transformers:
 - observe:
     files:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   test: '^0.12.18+1'
   stack_trace: '>=0.9.1 <2.0.0'
 environment:
-  sdk: ">=1.25.0 <2.0.0"
+  sdk: ">=2.0.0-dev <3.0.0"
 transformers:
 - observe:
     files:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   test: '^0.12.18+1'
   stack_trace: '>=0.9.1 <2.0.0'
 environment:
-  sdk: ">=2.0.0-dev.0.1 <2.0.0-dev.infinity"
+  sdk: ">=1.24.0 <2.0.0"
 transformers:
 - observe:
     files:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   test: '^0.12.18+1'
   stack_trace: '>=0.9.1 <2.0.0'
 environment:
-  sdk: ">=2.0.0-dev <3.0.0"
+  sdk: ">=2.0.0-dev.0.1 <2.0.0-dev.infinity"
 transformers:
 - observe:
     files:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: observe
-version: 0.15.1
+version: 0.15.2
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: >
   Observable properties and objects for use in template_binding.


### PR DESCRIPTION
The `dart:async` zone API is in the process of becoming strong-mode clean.
This patch fixes a breakage introduced by this change.